### PR TITLE
Create container methods for Azure

### DIFF
--- a/storage_helper/__init__.py
+++ b/storage_helper/__init__.py
@@ -692,7 +692,7 @@ def create_container(conn: Union[str, dict], container_name: str) -> str:
         raise Exception(f'Container "{container_name}" already exists')
 
 
-def generate_container_access_token(conn: Union[str, dict], container_name: str, expiry: datetime = None):
+def generate_container_access_token(conn: Union[str, dict], container_name: str, expiry: datetime = None) -> str:
     """
     Generates SAS token for container_name and optional expiration date. One year from now if "expiry" not provided.
     """


### PR DESCRIPTION
We can use our standard format as default connection like 

```
{
  "AZURE_STORAGE_ACCESS_KEY": "...",
  "BUCKET_URI": "wasbs://cienjobdatastgus.blob.core.windows.net"
}
```

with storage account name already set we won't be able to create anything outside of that account.