### PR TITLE
Remove boto3 support

### DIFF
--- a/.github/workflows/build-check.yaml
+++ b/.github/workflows/build-check.yaml
@@ -1,0 +1,17 @@
+name: Build check
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Build requirements.txt
+        run: pip install -r requirements.txt


### PR DESCRIPTION
Cien only supports azure storage.  As such, boto3 has been removed.